### PR TITLE
Quickfix for monstergroup

### DIFF
--- a/40K/monstergroups.json
+++ b/40K/monstergroups.json
@@ -2,9 +2,11 @@
 	{
 	"type":"monstergroup",
 	"name" : "GROUP_NID",
-	"default" : "tyranids",
+	"default" : "hgaunt",
 	"monsters" : [
-	{ "monster" : "hgaunt", "freq" : 2, "cost_multiplier": 5, "pack_size": [15,20]}
+	{ "monster" : "hgaunt", "freq" : 20, "cost_multiplier": 5, "pack_size": [15,20]},
+	{ "monster" : "geasetealer", "freq" : 4, "cost_multiplier": 5, "pack_size": [1,5]},
+	{ "monster" : "tyn_warrior", "freq" : 5, "cost_multiplier": 5, "pack_size": [10,15]}
 	],
 	"replace_monster_group" : true,
 	"new_monster_group_id" : "GROUP_NID_SMALL",


### PR DESCRIPTION
* Changed the default monster to cite an actual monster ID, instead of a
species.
* Also added genestealers and warriors to the monster selection, unsure
about ideal rarities.

Minor silliness, monster ID of genestealer is spelled geasetealer instead. :v